### PR TITLE
修复 Puppeteer 依赖冲突

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "postcss-loader": "^8.2.0",
     "prettier": "^3.6.2",
     "puppeteer": "^24.19.0",
-    "rize": "^0.9.0",
     "selenium-webdriver": "^4.35.0",
     "swc-loader": "^0.2.6",
     "tailwindcss": "^4.1.13",


### PR DESCRIPTION
## 🔧 修复 Puppeteer 依赖冲突

解决 `rize` 包与 `puppeteer` 的版本冲突。

## 🐛 问题

```
ERESOLVE unable to resolve dependency tree
rize@0.9.0 需要 puppeteer@^3.1.0
但项目使用的是 puppeteer@^24.19.0
```

## ✅ 解决方案

**移除过时的 `rize` 包**
- `rize` 是一个已过时的测试库（最后更新于 2019 年）
- 与现代版本的 puppeteer 不兼容
- 项目已经有更好的测试工具：
  - ✅ **Cypress** - E2E 测试
  - ✅ **BackstopJS** - 视觉回归测试  
  - ✅ **Jest** - 单元测试

## 📦 现在可以正常安装

```bash
npm install
```